### PR TITLE
Analisa dan lihat kode eror

### DIFF
--- a/vless-trojan-worker.js
+++ b/vless-trojan-worker.js
@@ -116,7 +116,7 @@ async function handleHttpRequest(request, url) {
 // ======= WEBSOCKET HANDLER =======
 async function handleWebSocketConnection(request, url) {
   // Extract target from path
-  const pathMatch = url.pathname.match(/^\\/(.+)$/);
+  const pathMatch = url.pathname.match(/^\/(.+)$/);
   let proxyTarget = "";
   
   if (pathMatch) {

--- a/worker.js
+++ b/worker.js
@@ -41,7 +41,7 @@ export default {
       // Handle WebSocket connections
       if (upgradeHeader === "websocket") {
         // Extract target from path
-        const pathMatch = url.pathname.match(/^\\/(.+)$/);
+        const pathMatch = url.pathname.match(/^\/(.+)$/);
         if (pathMatch) {
           // Set proxy target from path
           const proxyTarget = pathMatch[1];


### PR DESCRIPTION
Fix regex pattern in `worker.js` and `vless-trojan-worker.js` to correctly match URL paths for WebSocket connections.

---
<a href="https://cursor.com/background-agent?bcId=bc-93768328-4879-440b-b242-892d6bd650c3">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg">
    <img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg">
  </picture>
</a>
<a href="https://cursor.com/agents?id=bc-93768328-4879-440b-b242-892d6bd650c3">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg">
    <img alt="Open in Web" src="https://cursor.com/open-in-web.svg">
  </picture>
</a>



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Corrected URL path parsing for WebSocket and TCP routing so single-slash paths are recognized.
  * Restores proper handling of path-based proxies; WebSocket upgrades now proceed when a valid path is provided.
  * Improves routing reliability, reducing unexpected connection failures/timeouts for path-based connections.
  * No configuration or public API changes required; all other behaviors remain unchanged.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->